### PR TITLE
Fix incorrect ATP time-range assertions

### DIFF
--- a/code/Test_definitions/predictive-connectivity-data.feature
+++ b/code/Test_definitions/predictive-connectivity-data.feature
@@ -40,8 +40,7 @@ Feature: CAMARA Predictive Connectivity Data API, vwip
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/ConnectivityDataResponse"
     And the response property "$.status" value is "SUPPORTED_AREA"
-    And the response property "$.timedConnectivityData[*].startTime" is equal to or later than request body property "$.startTime"
-    And the response property "$.timedConnectivityData[*].endTime" is equal to or earlier than request body property "$.endTime"
+    And the response property "$.timedConnectivityData" intervals fully cover the requested time range from "$.startTime" to "$.endTime"
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].geohash" is a valid Geohash inside the request area
     And all the items in response property "$.timedConnectivityData[*].cellConnectivityData[*].layerConnectivities[*]" are equal to "GC", "MC" or "NC"
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].layerSignalStrengths" is not included in the response
@@ -57,10 +56,9 @@ Feature: CAMARA Predictive Connectivity Data API, vwip
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/ConnectivityDataResponse"
     And the response property "$.status" value is "PART_OF_AREA_NOT_SUPPORTED"
-    And the response property "$.timedConnectivityData[*].startTime" is equal to or later than request body property "$.startTime"
-    And the response property "$.timedConnectivityData[*].endTime" is equal to or earlier than request body property "$.endTime"
+    And the response property "$.timedConnectivityData" intervals fully cover the requested time range from "$.startTime" to "$.endTime"
     And there is at least one item in response property "$.timedConnectivityData[*].cellConnectivityData[*]"
-    And that item has an array property "$.timedConnectivityData[*].cellConnectivityData[*].layerConnectivities[*]" containing only "ND" values
+    And that item has the array property "$.timedConnectivityData[*].cellConnectivityData[*].layerConnectivities[*]" containing only "ND" values
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].layerConnectivities" is not empty
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].layerSignalStrengths" is not included in the response
 
@@ -178,8 +176,7 @@ Feature: CAMARA Predictive Connectivity Data API, vwip
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/ConnectivityDataResponse"
     And the response property "$.status" value is "SUPPORTED_AREA"
-    And the response property "$.timedConnectivityData[*].startTime" is equal to or later than request body property "$.startTime"
-    And the response property "$.timedConnectivityData[*].endTime" is equal to or earlier than request body property "$.endTime"
+    And the response property "$.timedConnectivityData" intervals fully cover the requested time range from "$.startTime" to "$.endTime"
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].geohash" is a valid Geohash inside the request area
     And all the items in response property "$.timedConnectivityData[*].cellConnectivityData[*].layerConnectivities[*]" are equal to "GC", "MC" or "NC"
     And the response property "$.timedConnectivityData[*].cellConnectivityData[*].layerSignalStrengths" is not included in the response


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction
* tests

#### What this PR does / why we need it:

This PR fixes incorrect ATP validation steps for time interval coverage in Predictive Connectivity Data.

The current ATP steps wrongly assume that each returned interval must be strictly contained within the requested time range. However, according to the specification, the returned intervals must fully cover the requested time range, which means:
- the first interval may start before the requested start time, and
- the last interval may end after the requested end time.

This PR updates the affected ATP checks so that they validate coverage semantics instead of boundary containment, aligning the tests with the API specification and avoiding false negatives in compliant implementations.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #45 

#### Special notes for reviewers:

This PR does not change API behavior. It only corrects ATP validation logic so that it matches the interval coverage semantics defined in the specification.

#### Changelog input

```
 release-note
Fix ATP time-range validation in Predictive Connectivity Data to check interval coverage semantics instead of strict interval containment.

```

#### Additional documentation 

This section can be blank.



```
docs

```
