### PR TITLE
Update Release Plan according to Sync26

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,9 +25,8 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-commonalities_release: r4.2
-identity_consent_management_release: r4.2
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: predictive-connectivity-data
     target_api_version: 0.2.0
-    target_api_status: alpha
+    target_api_status: public
     main_contacts:
       - eric-murray
       - albertoramosmonagas

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: predictive-connectivity-data
     target_api_version: 0.2.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - eric-murray
       - albertoramosmonagas

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -26,7 +26,8 @@ repository:
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
   commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+commonalities_release: r4.2
+identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,17 +10,17 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.2
+  target_release_tag: r1.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,8 +33,8 @@ dependencies:
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: predictive-connectivity-data
-    target_api_version: 0.1.0
-    target_api_status: public
+    target_api_version: 0.2.0
+    target_api_status: alpha
     main_contacts:
       - eric-murray
       - albertoramosmonagas

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.3
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* repository management

#### What this PR does / why we need it:

This PR updates the repository release plan for the Sync26 meta-release.

It aligns the `release-plan.yaml` with the next CAMARA release cycle by:
- setting the repository participation to `Sync26`
- updating the planned release information for this repository
- aligning the declared dependency releases with the target cycle

This is needed so the repository is correctly tracked by the Release Management automation and remains consistent with the current CAMARA release planning process.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #39 

#### Special notes for reviewers:

Please review this PR from a release planning perspective.

This change does not modify API behavior or implementation. It only updates the repository release declaration so it is correctly aligned with the Sync26 planning cycle and Release Management tooling.

#### Changelog input

```
 release-note
Update release-plan.yaml to align this repository with the Sync26 meta-release planning cycle.
```

#### Additional documentation 

This section can be blank.


```
docs

```
