### PR TITLE
add tele-operation service level

### DIFF
--- a/code/API_definitions/predictive-connectivity-data.yaml
+++ b/code/API_definitions/predictive-connectivity-data.yaml
@@ -433,11 +433,13 @@ components:
         service levels are as follows:
           - C2: Command and Control. Consists in connecting an unmanned aerial vehicle with its remote controller. This link allows data transmission in both directions, facilitating real-time operation and feedback.
           - STREAM_4K: Streaming in 4K quality.
+          - TELE_OPERATION: Intended for vehicle tele-operation in the automotive sector. Combination of low-latency actuation and low-latency, high-throughput sensor feedback (e.g. camera feeds).
           - BEST_EFFORT: This service level provides a qualitative estimation of coverage based on each operator's own prediction models or public coverage maps. It does not imply any guarantee of network performance or service availability. The values of GC, MC, NC, and ND should be interpreted as approximate indicators of expected connectivity quality, not as results derived from standardised thresholds.
       type: string
       enum:
         - C2
         - STREAM_4K
+        - TELE_OPERATION
         - BEST_EFFORT
     NetworkType:
       description: >-


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature

Fixes #53 

#### What this PR does / why we need it:

TNO, within the European funded [ENVELOPE project](https://envelope-project.eu/), is using the predictive connectivity data API to facilitate a tele-operated use case, with automotive industry partners. To this end, we have added a new value to the `ServiceLevel` enum in our deployment. We think it would be a good addition to the API.
