### PR TITLE
Add type definition for CellConnectivityData

### DIFF
--- a/code/API_definitions/predictive-connectivity-data.yaml
+++ b/code/API_definitions/predictive-connectivity-data.yaml
@@ -702,6 +702,7 @@ components:
       minItems: 1
       maxItems: 10000
     CellConnectivityData:
+      type: object
       description: >-
         Represents a rectangular grid cell within the specified area, including
         its connectivity data.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
The CellConnectivityData schema is missing a type definition, which will cause a CAMARA validation linter error. This PR adds a type definition.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
CAMARA validation is still failing because of the `null` field in one of the examples. But this PR can nonetheless be merged to fix the error that will be detected because of the missing type definition.

#### Changelog input
```
 release-note
 - Add type definition for CellConnectivityData
```

#### Additional documentation 
None